### PR TITLE
refactor/임상 시험 정보 리펙토링

### DIFF
--- a/src/clinical/clinical.controller.ts
+++ b/src/clinical/clinical.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ClinicalService } from './clinical.service';
 import { QueryDto } from './dto/Query.dto';
 import { Clinical } from './entities/clinical.entity';
@@ -16,5 +16,10 @@ export class ClinicalController {
   @Get(':id')
   async findOneClinical(@Param('id') id: string): Promise<Clinical> {
     return this.clinicalService.findOneClinical(Number(id));
+  }
+
+  @Post()
+  async getAllBatchDataForLocalTest(): Promise<void> {
+    return this.clinicalService.batchData();
   }
 }

--- a/src/clinical/clinical.repository.ts
+++ b/src/clinical/clinical.repository.ts
@@ -1,4 +1,4 @@
-import { addHours, set, subDays, subHours } from 'date-fns';
+import { set, subDays, add, subHours } from 'date-fns';
 import {
   Between,
   EntityRepository,
@@ -36,11 +36,18 @@ export class ClinicalRepository extends Repository<Clinical> {
     }
 
     if (query.APPROVAL_TIME) {
+      const UTCZeroApprovalTime = subHours(new Date(query.APPROVAL_TIME), 9);
+      const datePeriod = [
+        UTCZeroApprovalTime.toISOString(),
+        add(UTCZeroApprovalTime, {
+          hours: 23,
+          minutes: 59,
+          seconds: 59,
+        }).toISOString(),
+      ];
+
       Object.assign(whereOption, {
-        APPROVAL_TIME: Between(
-          subDays(subHours(new Date(query.APPROVAL_TIME), 9), 1).toISOString(),
-          subDays(addHours(new Date(query.APPROVAL_TIME), 15), 1).toISOString(),
-        ),
+        APPROVAL_TIME: Between(datePeriod[0], datePeriod[1]),
       });
     } else {
       Object.assign(whereOption, {

--- a/src/clinical/clinical.service.spec.ts
+++ b/src/clinical/clinical.service.spec.ts
@@ -124,9 +124,6 @@ describe('ClinicalService', () => {
   describe('createClinical', () => {
     it('clinical 생성에 성공한다', async () => {
       expect.assertions(7);
-      jest
-        .spyOn(service, 'convertKstToUtc')
-        .mockReturnValue('2021-11-16 09:00:00');
       const stepId = 1;
       const stepName = '1상';
 

--- a/src/clinical/clinical.service.ts
+++ b/src/clinical/clinical.service.ts
@@ -3,8 +3,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cron, Timeout } from '@nestjs/schedule';
 import * as xml2json from 'xml2json-light';
-import * as moment from 'moment-timezone';
-
+import { set } from 'date-fns';
 import { ClinicalRepository } from './clinical.repository';
 import { QueryDto } from './dto/Query.dto';
 import { StepService } from '../step/step.service';
@@ -55,7 +54,12 @@ export class ClinicalService {
   }
 
   async createClinical(clinical): Promise<Clinical> {
-    clinical.APPROVAL_TIME = this.convertKstToUtc(clinical.APPROVAL_TIME);
+    clinical.APPROVAL_TIME = set(new Date(clinical.APPROVAL_TIME), {
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
 
     const step = await this.getStep(clinical.CLINIC_STEP_NAME);
 
@@ -76,16 +80,6 @@ export class ClinicalService {
     }
 
     return step;
-  }
-
-  //KST to UTC
-  convertKstToUtc(time): string {
-    const KSTApprovalTime = new Date(time).getTime();
-    const modifiedApprovalTime = moment(KSTApprovalTime).format(
-      'YYYY-MM-DD HH:mm:ss',
-    );
-
-    return modifiedApprovalTime;
   }
 
   async findOneClinical(id: number): Promise<Clinical> {


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트

## 작업 개요
- 임상 시험 정보를 저장할 때, 그리고 조회할 때의 코드를 수정했습니다.

## 상세 내용

#### 임상 정보를 저장할 때

API 에서 제공하는 승인 시간은 "2012-02-28 00:00:00"으로 시, 분, 초를 모두 0으로 하고 있습니다. 하지만 기존의 코드에서는 저장할 당시의 모든 시간을 저장하고, UTC+0 시간대로 변환하지 않으며, date-fns 가 아닌 moment-timezone 을 사용하고 있었습니다.

```typescript
// 기존의 코드
function convertKstToUtc(time): string {
  const KSTApprovalTime = new Date(time).getTime();
  const modifiedApprovalTime = moment(KSTApprovalTime).format(
    'YYYY-MM-DD HH:mm:ss'
  );

  return modifiedApprovalTime;
}
clinical.APPROVAL_TIME = this.convertKstToUtc(clinical.APPROVAL_TIME);
```

```typescript
// 수정한 코드
clinical.APPROVAL_TIME = set(new Date(clinical.APPROVAL_TIME), {
  hours: 0,
  minutes: 0,
  seconds: 0,
  milliseconds: 0,
});
```

- 빌드할 용량을 줄이고 시간을 절약하기 위해 moment-timezone 을 제거하고 date-fns 의 `set` 함수를 사용했습니다.
  - `set` 함수로 시, 분, 초를 설정할 수 있는데, UTC+0 시간대에 시, 분, 초를 모두 0으로 설정하여 저장하도록 수정했습니다.
- `set` 함수로 날짜를 제어하면서 불필요해진 convertKstToUtc 메소드를 제거했습니다.

#### 임상 정보를 조회할 때


```typescript
// 기존의 코드
Object.assign(whereOption, {
  APPROVAL_TIME: Between(
    subDays(subHours(new Date(query.APPROVAL_TIME), 9), 1).toISOString(),
    subDays(addHours(new Date(query.APPROVAL_TIME), 15), 1).toISOString()
  ),
});
```

```typescript
// 수정한 코드
const UTCZeroApprovalTime = subHours(new Date(query.APPROVAL_TIME), 9);
const datePeriod = [
  UTCZeroApprovalTime.toISOString(),
  add(UTCZeroApprovalTime, {
    hours: 23,
    minutes: 59,
    seconds: 59,
  }).toISOString(),
];

Object.assign(whereOption, {
  APPROVAL_TIME: Between(datePeriod[0], datePeriod[1]),
});
```

- `new Date(query.APPROVAL_TIME)`을 두 번 선언해 중복이 발생하는 것을 막기 위해 `UTCZeroApprovalTime` 변수를 만들었습니다.
- 시간 조건을 0시 0분 0초 ~ 23시 59분 59초로 설정했습니다. 위의 코드를 그대로 사용하면 이틀을 조회하기 떄문입니다.