### PR TITLE
refactoring/임상 정보의 저장 및 batch task 수정, env 검증 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 프리온보딩 백엔드 과정 5번째 과제: 휴먼스케이프
 
-[휴먼스케이프](https://humanscape.io/kr/index.html)에서 제공해주신 API 설계 과제입니다. 헤로쿠를 이용해 배포했으며, 주소는 [https://pocky-humanscape-subject.herokuapp.com/](https://pocky-humanscape-subject.herokuapp.com/)입니다.
+[휴먼스케이프](https://humanscape.io/kr/index.html)에서 제공해주신 API 설계 과제입니다. 헤로쿠를 이용해 배포했으며, 주소는 [https://preonboarding-cardoc-api.herokuapp.com](https://preonboarding-cardoc-api.herokuapp.com)입니다.
 
 ## 과제에 대한 안내
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -673,6 +673,19 @@
         }
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -1171,6 +1184,24 @@
         "consola": "^2.15.0",
         "node-fetch": "^2.6.1"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -4926,6 +4957,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.5.0.tgz",
+      "integrity": "sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "date-fns": "^2.25.0",
+    "joi": "^17.5.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import * as Joi from 'joi';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ClinicalModule } from './clinical/clinical.module';
@@ -12,6 +13,10 @@ import { StepModule } from './step/step.module';
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '.env',
+      validationSchema: Joi.object({
+        SERVICE_URL: Joi.string().required(),
+        SERVICE_KEY: Joi.string().required(),
+      }),
     }),
     TypeOrmModule.forRoot({
       type: 'sqlite',

--- a/src/clinical/clinical.controller.ts
+++ b/src/clinical/clinical.controller.ts
@@ -19,7 +19,10 @@ export class ClinicalController {
   }
 
   @Post()
-  async getAllBatchDataForLocalTest(): Promise<void> {
-    return this.clinicalService.batchData();
+  async createAllDataForInitialSetting(): Promise<string> {
+    const result = await this.clinicalService.createAllDataForInitialSetting();
+    return result
+      ? '초기 데이터 저장에 성공했습니다.'
+      : '초기 데이터 저장에 실패했습니다.';
   }
 }

--- a/src/clinical/clinical.service.ts
+++ b/src/clinical/clinical.service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Cron, Timeout } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import * as xml2json from 'xml2json-light';
 import { set } from 'date-fns';
 import { ClinicalRepository } from './clinical.repository';
@@ -26,46 +26,15 @@ export class ClinicalService {
     return await this.clinicalRepository.getListClinical(query);
   }
 
-  async getAPIData(pageNo, start = 0): Promise<Clinical[]> {
-    let url =
-      'http://apis.data.go.kr/1470000/MdcinClincTestInfoService/getMdcinClincTestInfoList';
-    url += '?' + `ServiceKey=${process.env.SERVICE_KEY}`;
-    url += '&' + `numOfRows=${CLINICAL_CONSTANT.NUM_OF_ROWS}`;
-    url += '&' + `pageNo=${pageNo}`;
-
-    return this.httpService
-      .get(url)
-      .toPromise()
-      .then(async (axiosResponse) => {
-        const jsonResponse = xml2json.xml2json(axiosResponse.data);
-        const items = jsonResponse.response.body.items.item; // 임상 실험 데이터 배열
-
-        if (!items) {
-          return;
-        }
-
-        // DB에 insert
-        for (let i = start; i < items.length; i++) {
-          await this.createClinical(items[i]);
-        }
-
-        return items;
-      });
+  async findOneClinical(id: number): Promise<Clinical> {
+    const result = await this.clinicalRepository.findOne(id);
+    if (!result) {
+      throw new NotFoundException('유효한 임상 번호가 아닙니다.');
+    }
+    return result;
   }
 
-  async createClinical(clinical): Promise<Clinical> {
-    clinical.APPROVAL_TIME = set(new Date(clinical.APPROVAL_TIME), {
-      hours: 0,
-      minutes: 0,
-      seconds: 0,
-      milliseconds: 0,
-    });
-
-    const step = await this.getStep(clinical.CLINIC_STEP_NAME);
-
-    return await this.clinicalRepository.save({ ...clinical, step });
-  }
-
+  // --- 임상 시험 정보 저장 시작 ---
   async getStep(clinicStepName): Promise<Step> {
     // api의 CLINIC_STEP_NAME 이 존재 하지않을 경우 '기타' 로 등록
     if (clinicStepName === '') {
@@ -82,16 +51,79 @@ export class ClinicalService {
     return step;
   }
 
-  async findOneClinical(id: number): Promise<Clinical> {
-    const result = await this.clinicalRepository.findOne(id);
-    if (!result) {
-      throw new NotFoundException('유효한 임상 번호가 아닙니다.');
-    }
-    return result;
+  async createClinical(clinical): Promise<Clinical> {
+    clinical.APPROVAL_TIME = set(new Date(clinical.APPROVAL_TIME), {
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+    const step = await this.getStep(clinical.CLINIC_STEP_NAME);
+
+    return await this.clinicalRepository.save({ ...clinical, step });
   }
 
-  // 매주 월~토요일 0시 0분 0초에 배치 작업 수행
-  @Cron('0 0 0 * * 1-6')
+  async getAPIData(pageNo, start = 0): Promise<Clinical[]> {
+    let url = process.env.SERVICE_URL;
+    url += '?' + `serviceKey=${process.env.SERVICE_KEY}`;
+    url += '&' + `numOfRows=${CLINICAL_CONSTANT.NUM_OF_ROWS}`;
+    url += '&' + `pageNo=${pageNo}`;
+
+    return this.httpService
+      .get(url)
+      .toPromise()
+      .then(async (axiosResponse) => {
+        const jsonResponse = xml2json.xml2json(axiosResponse.data);
+        const items = jsonResponse.response.body.items.item; // 임상 실험 데이터 배열
+        if (!items) {
+          return;
+        }
+
+        // DB에 insert
+        for (let i = start; i < items.length; i++) {
+          await this.createClinical(items[i]);
+        }
+
+        return items;
+      });
+  }
+
+  async createAllDataForInitialSetting(): Promise<boolean> {
+    let pageNo = 1;
+
+    try {
+      let data = await this.getAPIData(pageNo, 0);
+      // API에서 빈 페이지를 가져오면 while 종료
+      while (data) {
+        pageNo++;
+        data = await this.getAPIData(pageNo);
+      }
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+  // --- 임상 시험 정보 저장 끝 ---
+
+  // --- Batch Data Start ---
+  getApiTotalCount(): Promise<number> {
+    let url = process.env.SERVICE_URL;
+    url += '?' + `ServiceKey=${process.env.SERVICE_KEY}`;
+    url += '&' + `numOfRows=${1}`;
+    url += '&' + `pageNo=${1}`;
+
+    return this.httpService
+      .get(url)
+      .toPromise()
+      .then(async (axiosResponse) => {
+        const jsonResponse = xml2json.xml2json(axiosResponse.data);
+        return jsonResponse.response.body.totalCount;
+      });
+  }
+
+  // 월 ~ 금요일 0시 0분 0초(한국 시간대)에 배치 작업 수행
+  @Cron('0 0 15 * * 1-6')
   async batchData(): Promise<void> {
     // api에서 데이터를 가져온다 totalCount를 읽는다
     const apiTotalCount = await this.getApiTotalCount();
@@ -112,32 +144,15 @@ export class ClinicalService {
     }
   }
 
-  // 초기 데이터 입력
-  @Timeout(1000)
-  async enterInitialData(): Promise<void> {
-    let pageNo = 1;
-
-    let data = await this.getAPIData(pageNo, 0);
-    // API에서 빈 페이지를 가져오면 while 종료
-    while (data) {
-      pageNo++;
-      data = await this.getAPIData(pageNo);
-    }
-  }
-
-  getApiTotalCount(): Promise<number> {
-    let url =
-      'http://apis.data.go.kr/1470000/MdcinClincTestInfoService/getMdcinClincTestInfoList';
-    url += '?' + `ServiceKey=${process.env.SERVICE_KEY}`;
-    url += '&' + `numOfRows=${1}`;
-    url += '&' + `pageNo=${1}`;
-
+  @Cron('0 50 14 * * 1-6')
+  async awakeHerkuServer(): Promise<void> {
     return this.httpService
-      .get(url)
+      .get('https://preonboarding-cardoc-api.herokuapp.com/')
       .toPromise()
-      .then(async (axiosResponse) => {
-        const jsonResponse = xml2json.xml2json(axiosResponse.data);
-        return jsonResponse.response.body.totalCount;
+      .then(() => {
+        return;
       });
   }
+
+  // --- Bacth Data End ---
 }


### PR DESCRIPTION
## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트

## 작업 개요

- 공공 데이터로부터 임상 정보를 저장하는 방식과 batch task 를 수정하고 env 를 검증하는 과정을 추가했습니다.

## 상세 내용

- 공공 데이터의 요청 URL을 env의 `SERVICE_URL`으로 지정하도록 했습니다. 12월 10일에 URL이 바뀌어 테스트에서 에러가 발생했기 떄문입니다. env에 `SERVICE_URL`을 직접 입력해서 앞으로 URL이 바뀌더라도 대응할 수 있도록 했습니다.
- [Joi](https://www.npmjs.com/package/joi)에서 env 파일의 내용을 검증하는 과정을 추가했습니다.
- 기존에는 서버를 실행하면 `@nest/schedule`을 이용해 10초 간격으로 데이터를 저장했습니다. 하지만 초기 데이터를 저장하는데 오랜 시간이 걸려 테스트를 수행할 준비가 됐는지 확인이 어려운 점, 그리고 직접 결과를 확인하는 것이 더 좋다고 생각해서 위의 기능을 제거하고 컨트롤러와 서비스에 `createAllDataForInitialSetting`메소드를 제작했습니다. POST `/clinical`으로 실행하며, 그에따라 API 문서의 내용도 수정했습니다.
- 헤로쿠는 30분동안 요청이 없으면 서버를 정지 상태로 만들기 떄문에 매주 batch task 를 하기 어렵습니다. 그것을 해결하기 위해 우선 23시 50분에 헤로쿠 URL을 요청해 서버를 꺠우고, 24시에 batch task 를 실행하도록 했습니다.
- 변경사항을 추가하여 새로운 헤로쿠 애플리케이션으로 배포했습니다.