### PR TITLE
fix/목록 조회 시 사용하는 승인 시간의 계산 과정을 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ export class QueryDto {
   @IsOptional()
   step?: string;
 }
+
+export class GetListRepositoryDto extends QueryDto {
+  NODE_ENV?: string | undefined;
+}
 ```
 
 - page: 몇 페이지인지를 명시합니다. pagination 에 사용하며 필수 값입니다.
@@ -104,6 +108,7 @@ export class QueryDto {
 - APPLY_ENTP_NAME: 임상 시험의 신청자입니다. 선택 사항으로, 검색에 사용합니다.
 - CLINIC_EXAM_TITLE: 임상 시험의 제목입니다. 선택 사항으로, 검색에 사용합니다.
 - step: 임상 시험의 단계입니다. [의약품안전나라 임상시험정보검색](https://nedrug.mfds.go.kr/searchClinic)의 임상시험단계 항목의 값을 문자열로 입력합니다. 선택 사항으로, 검색에 사용합니다.
+- NODE_ENV: 배포 환경인지 여부를 확인합니다. 헤로쿠에 배포했을 경우, 승인 시간을 UTC+0 시간대로 변환하지 않습니다.
 
 #### 데이터베이스에 접근해 필요한 임상 정보를 조회합니다.
 
@@ -140,7 +145,10 @@ if (query.step) {
 
 ```typescript
 if (query.APPROVAL_TIME) {
-  const UTCZeroApprovalTime = subHours(new Date(query.APPROVAL_TIME), 9);
+  let UTCZeroApprovalTime = new Date(query.APPROVAL_TIME);
+  if (query.NODE_ENV !== 'production') {
+    UTCZeroApprovalTime = subHours(UTCZeroApprovalTime, 9);
+  }
   const datePeriod = [
     UTCZeroApprovalTime.toISOString(),
     add(UTCZeroApprovalTime, {

--- a/src/clinical/clinical.repository.ts
+++ b/src/clinical/clinical.repository.ts
@@ -6,13 +6,13 @@ import {
   MoreThanOrEqual,
   Repository,
 } from 'typeorm';
-import { QueryDto } from './dto/Query.dto';
+import { GetListRepositoryDto } from './dto/Query.dto';
 import { Clinical } from './entities/clinical.entity';
 
 @EntityRepository(Clinical)
 export class ClinicalRepository extends Repository<Clinical> {
   async getListClinical(
-    query: QueryDto,
+    query: GetListRepositoryDto,
   ): Promise<{ data: Clinical[]; count: number }> {
     const limit = 10;
     const offset = query.page ? (Number(query.page) - 1) * limit : 0;
@@ -36,7 +36,10 @@ export class ClinicalRepository extends Repository<Clinical> {
     }
 
     if (query.APPROVAL_TIME) {
-      const UTCZeroApprovalTime = subHours(new Date(query.APPROVAL_TIME), 9);
+      let UTCZeroApprovalTime = new Date(query.APPROVAL_TIME);
+      if (query.NODE_ENV !== 'production') {
+        UTCZeroApprovalTime = subHours(UTCZeroApprovalTime, 9);
+      }
       const datePeriod = [
         UTCZeroApprovalTime.toISOString(),
         add(UTCZeroApprovalTime, {

--- a/src/clinical/clinical.service.ts
+++ b/src/clinical/clinical.service.ts
@@ -23,7 +23,10 @@ export class ClinicalService {
   async getListClinical(
     query: QueryDto,
   ): Promise<{ data: Clinical[]; count: number }> {
-    return await this.clinicalRepository.getListClinical(query);
+    return await this.clinicalRepository.getListClinical({
+      ...query,
+      NODE_ENV: process.env.NODE_ENV,
+    });
   }
 
   async findOneClinical(id: number): Promise<Clinical> {

--- a/src/clinical/dto/Query.dto.ts
+++ b/src/clinical/dto/Query.dto.ts
@@ -29,3 +29,7 @@ export class QueryDto {
   @IsOptional()
   step?: string;
 }
+
+export class GetListRepositoryDto extends QueryDto {
+  NODE_ENV?: string | undefined;
+}


### PR DESCRIPTION
## 작업 분류

- [x] 버그 수정
- [ ] 신규 기능 추가
- [ ] 리팩터링
- [ ] 테스트

## 작업 개요
- 승인 시간을 계산할 때 배포 환경인지를 확인하는 조건문을 추가했습니다.

## 상세 내용
- 오직 로컬 환경에서만 승인 시간을 UTC+0 시간대로 바꾸도록 조건문을 추가했습니다. 헤로쿠는 UTC+0 시간대를 기준으로 잡기 때문에 다시 변환할 필요가 없기 떄문입니다.
- 그에 맞춰 README 의 수행한 작업 항목의 내용도 수정했습니다.
